### PR TITLE
[WIP] Handle CHARMM patches

### DIFF
--- a/devtools/ci/travis/install.sh
+++ b/devtools/ci/travis/install.sh
@@ -34,6 +34,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv boost==1.59.0 -c omnia
         conda install -y -n myenv nglview -c bioconda
         conda install -y -n myenv ambertools=17.0 -c http://ambermd.org/downloads/ambertools/conda/
+        conda install -y -n myenv -c conda-forge networkx
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -857,10 +857,6 @@ class CharmmParameterSet(ParameterSet):
                                     hpatches[resname] = val
                                 elif tok.upper().startswith('LAST'):
                                     tpatches[resname] = val
-                        elif line[:5].upper() == 'DELETE':
-                            words = line.split()
-                            name = words[2].upper()
-                            res.delete.append(name)
                         elif line[:4].upper() in ('IMPR', 'IMPH'):
                             it = iter(w.upper() for w in line.split()[1:])
                             for a1, a2, a3, a4 in zip(it, it, it, it):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -812,9 +812,16 @@ class CharmmParameterSet(ParameterSet):
                             group.append(atom)
                             res.add_atom(atom)
                         elif line[:6].upper() == 'DELETE':
-                            words = line.split()
                             name = words[2].upper()
-                            res.delete.append(name)
+                            entity_type = words[1].upper()
+                            if entity_type == 'ATOM':
+                                res.delete_atoms.append(name)
+                            elif entity_type == 'IMPR':
+                                res.delete_impropers.append(words[2:5])
+                            else:
+                                msg = 'ParmEd cannot handle DELETE BOND, ANGL, DIHE, IMPR, DONO, or ACCE\n'
+                                msg += 'line was: %s' % line                                
+                                raise Exception(msg)
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
                             for a1, a2 in zip(it, it):

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -89,7 +89,6 @@ class CharmmParameterSet(ParameterSet):
         # Instantiate the list types
         super(CharmmParameterSet, self).__init__()
         self.parametersets = []
-        self.patches = dict()
         self._declared_nbrules = False
 
         # Load all of the files
@@ -903,10 +902,6 @@ class CharmmParameterSet(ParameterSet):
                     res.first_patch = self.patches[patch_name]
                 except KeyError:
                     warnings.warn('Patch %s not found' % patch_name)
-                    # DEBUG
-                    print('patches.keys()')
-                    print(patches.keys())
-                    print(patch_name in patches.keys())
 
             patch_name = tpatches[resname]
             if patch_name is not None:

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -729,6 +729,7 @@ class CharmmParameterSet(ParameterSet):
             f = tfile
         hpatch = tpatch = None # default Head and Tail patches
         residues = dict()
+        patches = dict()
         hpatches = dict()
         tpatches = dict()
         line = next(f)
@@ -820,7 +821,7 @@ class CharmmParameterSet(ParameterSet):
                                 res.delete_impropers.append(words[2:5])
                             else:
                                 msg = 'ParmEd cannot handle DELETE BOND, ANGL, DIHE, IMPR, DONO, or ACCE\n'
-                                msg += 'line was: %s' % line                                
+                                msg += 'line was: %s' % line
                                 raise Exception(msg)
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
@@ -879,7 +880,7 @@ class CharmmParameterSet(ParameterSet):
                     if restype == 'RESI':
                         residues[resname] = res
                     elif restype == 'PRES':
-                        self.patches[resname] = res
+                        patches[resname] = res
                     else:
                         assert False, 'restype != RESI or PRES'
                     # We parsed a line we need to look at. So don't update the
@@ -904,6 +905,7 @@ class CharmmParameterSet(ParameterSet):
                     warnings.warn('Patch %s not found' % tpatches[resname])
         # Now update the residues and patches with the ones we parsed here
         self.residues.update(residues)
+        self.patches.update(patches)
 
         if own_handle: f.close()
 

--- a/parmed/charmm/parameters.py
+++ b/parmed/charmm/parameters.py
@@ -828,6 +828,14 @@ class CharmmParameterSet(ParameterSet):
                         elif line.strip().upper() and line.split()[0].upper() in ('BOND', 'DOUBLE'):
                             it = iter([w.upper() for w in line.split()[1:]])
                             for a1, a2 in zip(it, it):
+                                if restype == 'PRES':
+                                    # Patches can have bonds that refer to atoms not in the patch, so store these in a list of tuples
+                                    order = 1
+                                    if line.split()[0].upper() == 'DOUBLE':
+                                        order = 2
+                                    res.add_bonds.append( (a1, a2, order) )
+                                    continue
+
                                 if a1.startswith('-'):
                                     res.head = res[a2]
                                     continue
@@ -839,12 +847,6 @@ class CharmmParameterSet(ParameterSet):
                                     continue
                                 if a2.startswith('+'):
                                     res.tail = res[a1]
-                                    continue
-                                # Apparently PRES objects do not need to put +
-                                # or - in front of atoms that belong to adjacent
-                                # residues
-                                if restype == 'PRES' and (a1 not in res or
-                                                          a2 not in res):
                                     continue
                                 res.add_bond(a1, a2)
                         elif line[:4].upper() == 'CMAP':

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -388,9 +388,15 @@ class ResidueTemplate(object):
         # Create a copy
         # TODO: Once ResidueTemplate.from_residue() actually copies all info, use that instead?
         residue = _copy.copy(self)
-        # Process patch
+        # Delete atoms
         for atom_name in patch.delete_atoms:
             residue.delete_atom(atom_name)
+        # Replace atoms
+        for atom in patch.atoms:
+            if atom.name in residue:
+                # Overwrite type and charge
+                residue[atom.name].type = atom.type
+                residue[atom.name].charge = atom.charge
         # Delete impropers
         for impr in patch.delete_impropers:
             residue.remove(impr)

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -143,7 +143,7 @@ class ResidueTemplate(object):
             atom_name = atom.name
 
         if atom_name not in self._map:
-            raise RuntimeError("Could not find atom '%s' in ResidueTemplate, which contains atoms: %s" % (atom_name, self._map.keys()))
+            raise RuntimeError("Could not find atom '%s' in ResidueTemplate, which contains atoms: %s" % (atom_name, list(self._map.keys())))
 
         atom = self._map[atom_name]
 
@@ -257,7 +257,6 @@ class ResidueTemplate(object):
                         inst.connections.append(inst.atoms[idx])
                 else:
                     inst.add_bond(i1, i2)
-        # TODO: Does this method neglect to copy other information, like head, tail, patches, and impropers?
         return inst
 
     @property
@@ -434,7 +433,7 @@ class ResidueTemplate(object):
                 # Add bond
                 residue.add_bond(atom1_name, atom2_name, order)
             except:
-                raise Exception('Bond %s-%s could not be added to patched residue: %s' % (atom1_name, atom2_name))
+                raise Exception('Bond %s-%s could not be added to patched residue: atoms are %s' % (atom1_name, atom2_name, list(residue._map.keys())))
         # Delete impropers
         for impr in patch.delete_impropers:
             try:

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -333,6 +333,16 @@ class ResidueTemplate(object):
 
         return self
 
+    def apply_patch(self, patch):
+        """
+        Apply the specified PatchTemplate to the ResidueTemplate.
+
+        TODO:
+        * How do we handle patches that involve more than one residue?
+        """
+        # TODO
+        raise Exception('Not implemented.')
+
     def to_dataframe(self):
         """ Create a pandas dataframe from the atom information
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -224,6 +224,10 @@ class ResidueTemplate(object):
             self._crd = np.array([[a.xx, a.xy, a.xz] for a in self])
         return self._crd
 
+    @property
+    def net_charge(self):
+        return sum([a.charge for a in self])
+
     # Make ResidueTemplate look like a container of atoms, also indexable by the
     # atom name
     def __len__(self):
@@ -311,7 +315,7 @@ class ResidueTemplate(object):
         """
         if not self.atoms:
             raise ValueError('Cannot fix charges on an empty residue')
-        net_charge = sum(a.charge for a in self.atoms)
+        net_charge = self.net_charge
         if to is None:
             to = round(net_charge)
         else:

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -439,6 +439,11 @@ class ResidueTemplate(object):
         is_integral = (round(net_charge, precision) - round(net_charge)) == 0.0
         if not is_integral:
             raise Exception('Patch is not compatible with residue due to non-integral charge (charge was %f).' % net_charge)
+        # Ensure residue is connected
+        import networkx as nx
+        G = residue.to_networkx()
+        if not nx.is_connected(G):
+            raise Exception('Patched residue bond graph is not a connected graph.')
 
         return residue
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -442,6 +442,23 @@ class ResidueTemplate(object):
 
         return residue
 
+    def to_networkx(self):
+        """ Create a NetworkX graph of atoms and bonds
+
+        Returns
+        -------
+        G : :class:`networkx.Graph`
+            A NetworkX Graph representing the molecule
+
+        """
+        import networkx
+        G = networkx.Graph()
+        for atom in self.atoms:
+            G.add_node(atom.name, charge=atom.charge, type=atom.type)
+        for bond in self.bonds:
+            G.add_edge(bond.atom1.name, bond.atom2.name)
+        return G
+
     def to_dataframe(self):
         """ Create a pandas dataframe from the atom information
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -397,6 +397,9 @@ class ResidueTemplate(object):
                 # Overwrite type and charge
                 residue[atom.name].type = atom.type
                 residue[atom.name].charge = atom.charge
+        # Add bonds
+        for bond in patch.bonds:
+            residue.add_bond(bond.atom1.name, bond.atom2.name)
         # Delete impropers
         for impr in patch.delete_impropers:
             residue.remove(impr)

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -540,7 +540,8 @@ class PatchTemplate(ResidueTemplate):
     """
     def __init__(self, name=''):
         super(PatchTemplate, self).__init__(name)
-        self.delete = []
+        self.delete_atoms = []
+        self.delete_impropers = []
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -397,6 +397,8 @@ class ResidueTemplate(object):
                 # Overwrite type and charge
                 residue[atom.name].type = atom.type
                 residue[atom.name].charge = atom.charge
+            else:
+                residue.add_atom(Atom(name=atom.name, type=atom.type, charge=atom.charge))
         # Add bonds
         for bond in patch.bonds:
             residue.add_bond(bond.atom1.name, bond.atom2.name)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -460,6 +460,7 @@ class OpenMMParameterSet(ParameterSet):
                     patched_residue = residue.apply_patch(patch)
                 except Exception as e:
                     # Patching failed; continue to next patch
+                    print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
                     continue
                 # Check that the net charge is integral.
                 net_charge = patched_residue.net_charge

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -429,7 +429,7 @@ class OpenMMParameterSet(ParameterSet):
             dest.write('  </Residue>\n')
         dest.write(' </Residues>\n')
 
-    def _determine_valid_patch_combinations(self, skip_residues, precision=4):
+    def _determine_valid_patch_combinations(self, skip_residues):
         """
         Determine valid (permissible) combinations of patches with residues that
         lead to integral net charges.
@@ -439,11 +439,6 @@ class OpenMMParameterSet(ParameterSet):
 
         skip_residues : set of ResidueTemplate
             List of residues to skip
-
-        precision : int, optional
-            Each valid patch should be produce a net charge that is integral to
-            this many decimal places.
-            Default is 4
 
         TODO:
         * residues and patches will need data structures to hold valid patches;
@@ -462,12 +457,9 @@ class OpenMMParameterSet(ParameterSet):
                     # Patching failed; continue to next patch
                     print('%8s x %8s : %s' % (patch.name, residue.name, str(e)))
                     continue
-                # Check that the net charge is integral.
-                net_charge = patched_residue.net_charge
-                is_integral = (round(net_charge, precision) - round(net_charge)) == 0.0
-                if is_integral:
-                    valid_patch_combinations[residue.name].append(patch.name)
-                    valid_patch_combinations[patch.name].append(residue.name)
+
+                valid_patch_combinations[residue.name].append(patch.name)
+                valid_patch_combinations[patch.name].append(residue.name)
         return valid_patch_combinations
 
     def _write_omm_patches(self, dest, valid_patch_combinations):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -460,6 +460,7 @@ class OpenMMParameterSet(ParameterSet):
 
                 valid_patch_combinations[residue.name].append(patch.name)
                 valid_patch_combinations[patch.name].append(residue.name)
+                                
         return valid_patch_combinations
 
     def _write_omm_patches(self, dest, valid_patch_combinations):

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -447,9 +447,9 @@ class OpenMMParameterSet(ParameterSet):
         """
         # Attempt to patch every residue, recording only valid combinations.
         valid_patch_combinations = defaultdict(list)
-        for residue in self.residues.values():
-            if residue in skip_residues: continue
-            for patch in self.patches.values():
+        for patch in self.patches.values():
+            for residue in self.residues.values():
+                if residue in skip_residues: continue
                 # Attempt to patch the residue.
                 try:
                     patched_residue = residue.apply_patch(patch)

--- a/parmed/openmm/parameters.py
+++ b/parmed/openmm/parameters.py
@@ -209,7 +209,8 @@ class OpenMMParameterSet(ParameterSet):
         # DEBUG
         print('Determining valid patch combinations...')
         valid_patch_combinations = self._determine_valid_patch_combinations(skip_residues)
-        print(valid_patch_combinations)
+        for patch_name in self.patches:
+            print('%8s : %s' % (patch_name, valid_patch_combinations[patch_name]))
         print('')
 
         if charmm_imp:

--- a/parmed/parameters.py
+++ b/parmed/parameters.py
@@ -90,6 +90,7 @@ class ParameterSet(object):
         self.parametersets = []
         self._combining_rule = 'lorentz'
         self.residues = OrderedDict()
+        self.patches = OrderedDict()
         self.default_scee = self.default_scnb = 1.0
 
     def __copy__(self):
@@ -145,6 +146,8 @@ class ParameterSet(object):
             other.cmap_types[tuple(reversed(key))] = typ
         for key, item in iteritems(self.residues):
             other.residues[key] = copy(item)
+        for key, item in iteritems(self.patches):
+            other.patches[key] = copy(item)
         other.combining_rule = self.combining_rule
 
         return other

--- a/test/test_parmed_charmm.py
+++ b/test/test_parmed_charmm.py
@@ -1042,6 +1042,13 @@ class TestCharmmParameters(utils.FileIOTestCase):
         else:
             self.assertEqual(a1, a2)
 
+    def test_charmm36_rtf(self):
+        """Test parsing of CHARMM36 RTF files."""
+        # Make sure there are no failures loading CHARMM36 RTF files.
+        param36 = parameters.CharmmParameterSet(get_fn('top_all36_prot.rtf'),
+                                                get_fn('top_all36_carb.rtf'),
+                                                get_fn('top_all36_cgenff.rtf'))
+
 class TestFileWriting(utils.FileIOTestCase):
     """ Tests the various file writing capabilities """
 

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -9,6 +9,10 @@ try:
     import pandas as pd
 except ImportError:
     pd = None
+try:
+    import networkx as nx
+except ImportError:
+    nx = None
 import os
 import parmed as pmd
 from parmed import Atom, read_PDB, Structure
@@ -54,6 +58,20 @@ class TestResidueTemplate(unittest.TestCase):
         self.assertEqual(df.shape, (6, 20))
         self.assertAlmostEqual(df.charge.sum(), 0)
         self.assertEqual(df.atomic_number.sum(), 23)
+
+    @unittest.skipIf(nx is None, "Cannot test without networkx")
+    def test_to_networkx(self):
+        """ Test converting ResidueTemplate to NetworkX graph """
+        a1, a2, a3, a4, a5, a6 = self.templ.atoms
+        self.templ.add_bond(a1, a2)
+        self.templ.add_bond(a2, a3)
+        self.templ.add_bond(a3, a4)
+        self.templ.add_bond(a5, a6)
+        G1 = self.templ.to_networkx()
+        assert not nx.is_connected(G1)
+        self.templ.add_bond(a2, a5)
+        G2 = self.templ.to_networkx()
+        assert nx.is_connected(G2)
 
     def test_add_atom(self):
         """ Tests the ResidueTemplate.add_atom function """

--- a/test/test_parmed_modeller.py
+++ b/test/test_parmed_modeller.py
@@ -15,6 +15,7 @@ from parmed import Atom, read_PDB, Structure
 from parmed.amber import AmberParm, AmberOFFLibrary
 from parmed.exceptions import AmberWarning, Mol2Error
 from parmed.modeller import (ResidueTemplate, ResidueTemplateContainer,
+                             PatchTemplate,
                              PROTEIN, SOLVENT, StandardBiomolecularResidues)
 from parmed.formats import Mol2File, PDBFile
 from parmed.geometry import distance2
@@ -235,6 +236,50 @@ class TestResidueTemplate(unittest.TestCase):
         rescont[0].fix_charges()
         for a, c in zip(rescont[0].atoms, charges):
             self.assertEqual(a.charge, c)
+
+    def test_delete_atom(self):
+        """ Tests the ResidueTemplate.delete_atom function """
+        templ = copy(self.templ)
+        a1, a2, a3, a4, a5, a6 = templ.atoms
+        a7 = Atom(name='Unimportant', type='black hole')
+        templ.add_bond(a1, a2)
+        templ.add_bond(a2, a3)
+        templ.add_bond(a3, a4)
+        templ.add_bond(a2, a5)
+        templ.add_bond(a5, a6)
+        templ.delete_atom(a6)
+        #self.assertRaises(RuntimeError, lambda: templ.delete_atom(a7))
+        self.assertIn(a1, a2.bond_partners)
+        self.assertIn(a2, a1.bond_partners)
+        self.assertIn(a3, a2.bond_partners)
+        self.assertIn(a2, a3.bond_partners)
+        self.assertIn(a5, a2.bond_partners)
+        self.assertIn(a2, a5.bond_partners)
+        self.assertNotIn(a5, a6.bond_partners)
+        self.assertNotIn(a6, a5.bond_partners)
+        self.assertEqual(len(templ.bonds), 4)
+
+    def test_patch_residue(self):
+        """ Tests ResidueTemplate.patch_residue function """
+        templ = self.templ
+        a1, a2, a3, a4, a5, a6 = templ.atoms
+        templ.add_bond(a1, a2)
+        templ.add_bond(a2, a3)
+        templ.add_bond(a3, a4)
+        templ.add_bond(a2, a5)
+        templ.add_bond(a5, a6)
+        patch = PatchTemplate()
+        patch.delete_atoms.append(a6.name)
+        residue = self.templ.apply_patch(patch)
+        self.assertEqual(len(residue.atoms), 5)
+        self.assertEqual(len(residue.bonds), 4)
+        a1, a2, a3, a4, a5 = residue.atoms
+        self.assertIn(a1, a2.bond_partners)
+        self.assertIn(a2, a1.bond_partners)
+        self.assertIn(a3, a2.bond_partners)
+        self.assertIn(a2, a3.bond_partners)
+        self.assertIn(a5, a2.bond_partners)
+        self.assertIn(a2, a5.bond_partners)
 
     def test_add_bonds_atoms(self):
         """ Tests the ResidueTemplate.add_bond function w/ indices """

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -583,7 +583,8 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
         openmm_params = openmm.OpenMMParameterSet.from_parameterset(charmm_params)
         print('openmm_params has %d residues and %d patches' % (len(openmm_params.residues), len(openmm_params.patches)))
 
-        openmm_params.write(get_fn('charmm.xml', written=True),
+        #openmm_params.write(get_fn('charmm.xml', written=True),
+        openmm_params.write(get_fn('charmm36.xml'),
                             provenance=dict(
                                 OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
                                 Reference='MacKerrell'

--- a/test/test_parmed_openmm.py
+++ b/test/test_parmed_openmm.py
@@ -576,17 +576,20 @@ Wang, J., Wolf, R. M.; Caldwell, J. W.;Kollman, P. A.; Case, D. A. "Development 
     def test_ljforce_charmm(self):
         """ Test writing LennardJonesForce without NBFIX from Charmm parameter files"""
 
-        params = openmm.OpenMMParameterSet.from_parameterset(
-                pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
-                                              get_fn('top_all36_prot.rtf'))
-        )
-        params.write(get_fn('charmm.xml', written=True),
-                     provenance=dict(
-                         OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
-                         Reference='MacKerrell'
-                     ),
-                     separate_ljforce=True
-        )
+        charmm_params = pmd.charmm.CharmmParameterSet(get_fn('par_all36_prot.prm'),
+                                                      get_fn('top_all36_prot.rtf'))
+
+        print('charmm_params has %d residues and %d patches' % (len(charmm_params.residues), len(charmm_params.patches)))
+        openmm_params = openmm.OpenMMParameterSet.from_parameterset(charmm_params)
+        print('openmm_params has %d residues and %d patches' % (len(openmm_params.residues), len(openmm_params.patches)))
+
+        openmm_params.write(get_fn('charmm.xml', written=True),
+                            provenance=dict(
+                                OriginalFile='par_all36_prot.prm & top_all36_prot.rtf',
+                                Reference='MacKerrell'
+                                ),
+                            separate_ljforce=True
+                            )
 
     def test_explicit_improper(self):
         """Test writing out the improper explicitly"""


### PR DESCRIPTION
This PR adds support for reading CHARMM patches and writing them in OpenMM ffxml format.

Patches are stored in the `ParameterSet`'s `.patches` field as an `OrderedDict`.

Single-residue patches are automatically tested against residues for compatibility by checking:
* all atoms to be changed or deleted are present
* all bonds to be added involve extant atoms
* the resulting net charge of the `ResidueTemplate` is neutral 

This testing is done using the `ResidueTemplate.apply_patch()` convenience function.

Remaining tasks:
- [ ] refine logic to `_write_omm_patches` that distinguishes patch atoms that are added vs modified and bonds that are deleted; currently, only one compatible patch x residue combination is checked
- [ ] `PatchTemplate` may need to implement its own `__copy__` to copy additional information it stores

cc: https://github.com/choderalab/openmm-forcefields/issues/22