### PR TITLE
Use lxml.etree to write OpenMM parameter set instead of forming strings manually

### DIFF
--- a/devtools/ci/travis/install.sh
+++ b/devtools/ci/travis/install.sh
@@ -35,6 +35,7 @@ else # Otherwise, CPython... go through conda
         conda install -y -n myenv nglview -c bioconda
         conda install -y -n myenv ambertools=17.0 -c http://ambermd.org/downloads/ambertools/conda/
         conda install -y -n myenv -c conda-forge networkx
+        conda install -y -n myenv -c conda-forge lxml        
     else
         # Do not install the full numpy/scipy stack
         conda create -y -n myenv python=$PYTHON_VERSION numpy nose pyflakes=1.0.0 \

--- a/parmed/modeller/residue.py
+++ b/parmed/modeller/residue.py
@@ -388,6 +388,7 @@ class ResidueTemplate(object):
         * The patch specifies that an atom is to be deleted that doesn't exist in the residue
         * A bond specified as being added in the patch does not have both atom names present after adding/deleting atoms from the patch
         * The new net charge is not integral to the specified precision
+        * The residue is not modified in any way (no atoms or bonds added/changed/deleted)
 
         Parameters
         ----------
@@ -411,10 +412,13 @@ class ResidueTemplate(object):
         # Create a copy
         # TODO: Once ResidueTemplate.from_residue() actually copies all info, use that instead?
         residue = _copy.copy(self)
+        # Record whether we've actually modified the residue.
+        topology_changed = False
         # Delete atoms
         for atom_name in patch.delete_atoms:
             try:
                 residue.delete_atom(atom_name)
+                modifications_made = True
             except KeyError as e:
                 raise IncompatiblePatchError(str(e))
         # Add or replace atoms
@@ -425,6 +429,7 @@ class ResidueTemplate(object):
                 residue[atom.name].charge = atom.charge
             else:
                 residue.add_atom(Atom(name=atom.name, type=atom.type, charge=atom.charge))
+                modifications_made = True
         # Add bonds
         for (atom1_name, atom2_name, order) in patch.add_bonds:
             try:


### PR DESCRIPTION
This will hopefully be much more robust than trying to form strings with proper handling of Unicode encodings manually.
